### PR TITLE
defer Attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "pug-loader": "^2.4.0",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.1.0",
+    "script-ext-html-webpack-plugin": "^2.1.4",
     "style-loader": "^0.23.0",
     "svg-icon-inline-loader": "^3.1.0",
     "uglifyjs-webpack-plugin": "^1.3.0",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OfflinePlugin = require("offline-plugin");
 const WebpackPwaManifest = require("webpack-pwa-manifest");
+const ScriptExtHtmlWebpackPlugin = require("script-ext-html-webpack-plugin");
 
 module.exports = isProd => {
   return {
@@ -68,6 +69,9 @@ module.exports = isProd => {
             ? "https://c4g6e6lp97.execute-api.us-east-1.amazonaws.com/production"
             : "http://localhost:3000"
         }/site-mailer`
+      }),
+      new ScriptExtHtmlWebpackPlugin({
+        defaultAttribute: "defer"
       }),
       new webpack.DefinePlugin({
         IS_PROD: isProd


### PR DESCRIPTION
Added `defer` attribute to script tag of primary JavaScript bundle code.

This allows the file to be downloaded during HTML parsing and executed only after the parser is completed.