### PR TITLE
Travis CI - Single Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,34 @@ node_js:
   - "lts/*"
   - 10
 
+cache: npm
+
 script:
   - npm install
   - npm run format:check
   - npm run lint
-  - npm run build:prod
 
-deploy:
-  provider: pages
-  skip-cleanup: true
-  local-dir: dist/
-  github-token: $GITHUB_API_KEY
-  keep-history: true
-  repo: kenchandev/kenchandev.github.io
-  target-branch: master
-  on:
-    branch: master
+jobs:
+  include:
+    - stage: build-prod
+      name: "Build Production Site"
+      os: linux
+      node_js: "lts/*"
+      script: npm run build:prod
+      if: branch = master
+    - stage: deploy
+      name: "Deploy to GitHub Pages"
+      os: linux
+      node_js: "lts/*"
+      script: echo "Deploying to GitHub Pages..."
+      if: branch = master
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        local-dir: dist/
+        github-token: $GITHUB_API_KEY
+        keep-history: true
+        repo: kenchandev/kenchandev.github.io
+        target-branch: master
+        on:
+          branch: master


### PR DESCRIPTION
Previous Travis CI configuration deployed the production build of the site six times due to 2 operating systems and 3 versions of Node.js being specified.

![](https://www.dl.dropboxusercontent.com/s/lysh34hb5xz1aed/Screenshot%202020-01-01%2021.18.22.png)

Hence, I refactored the Travis CI configuration to use build jobs to target a single operating system and single version of Node.js to execute the build and deployment once only. Visit the [documentation](https://docs.travis-ci.com/user/build-stages) for more information.