### PR TITLE
Travis CI - Build Patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,11 @@ script:
 
 jobs:
   include:
-    - stage: build-prod
-      name: "Build Production Site"
+    - stage: prod-build-deploy
+      name: "Build Production Site and Deploy to GitHub Pages"
       os: linux
       node_js: "lts/*"
-      script: npm run build:prod
-      if: branch = master
-    - stage: deploy
-      name: "Deploy to GitHub Pages"
-      os: linux
-      node_js: "lts/*"
-      script: echo "Deploying to GitHub Pages..."
+      script: npm run build:prod && echo "Deploying to GitHub Pages..."
       if: branch = master
       deploy:
         provider: pages


### PR DESCRIPTION
Consolidated `build-prod` and `deploy` job stages into a single job stage due to the `dist` folder of the build not being found during the execution of the `deploy` job stage.

![](https://www.dl.dropboxusercontent.com/s/t82i6v1d8k9cf79/Screenshot%202020-01-01%2022.18.24.png)