### PR TITLE
Critical CSS Dimension Adjustments

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -33,8 +33,8 @@ module.exports = () => {
         inline: true,
         minify: true,
         extract: true,
-        width: 375,
-        height: 565,
+        width: 1440,
+        height: 600,
         penthouse: {
           blockJSRequests: false
         }


### PR DESCRIPTION
With the latest integration of a Webpack plugin to inject critical CSS into the `index.html` file, the dimensions specified were for mobile devices. Hence, if the user visited the site on a desktop machine, because the critical CSS only contained the base mobile styles (and not the desktop styles since those remained in the external stylesheet that would be downloaded a bit after), for a very small amount of time, the mobile layout of the above-the-fold content is shown before the actual desktop layout is shown.