### PR TITLE
IE 11 Patches

### DIFF
--- a/assets/scripts/screenshots.js
+++ b/assets/scripts/screenshots.js
@@ -75,7 +75,9 @@ export const bindOnClickProjectFeatures = experiences => {
       currentActiveElement = element;
 
       renderScreenshot(
-        browserElement.getElementById(browserElement.dataset.targetId),
+        browserElement.getElementById(
+          browserElement.getAttribute("data-target-id")
+        ),
         {
           imageUrl,
           attrs: SCREENSHOT_ATTRS.BROWSER
@@ -130,9 +132,9 @@ export const bindOnScrollLazyImages = (experiences, callbacks) => {
         !mobile.isVisited &&
         isPartiallyVisible(mobile.element)
       ) {
-        callbacks[mobile.element.dataset.callback](
+        callbacks[mobile.element.getAttribute("data-callback")](
           mobile.element,
-          mobile.element.dataset.targetId
+          mobile.element.getAttribute("data-target-id")
         );
 
         mobile.isVisited = true;
@@ -141,9 +143,9 @@ export const bindOnScrollLazyImages = (experiences, callbacks) => {
         !browser.isVisited &&
         isPartiallyVisible(browser.element)
       ) {
-        callbacks[browser.element.dataset.callback](
+        callbacks[browser.element.getAttribute("data-callback")](
           browser.element,
-          browser.element.dataset.targetId
+          browser.element.getAttribute("data-target-id")
         );
 
         browser.isVisited = true;

--- a/assets/styles/components/_lists.scss
+++ b/assets/styles/components/_lists.scss
@@ -47,7 +47,7 @@
 
     &:not(:last-child)::after {
       content: "\00b7";
-      padding: 0 0.25em 0 0.5em;
+      padding: 0 0.5em;
     }
   }
 }


### PR DESCRIPTION
* `dataset` attribute on an `HTMLElement` is `undefined` in IE 11. Had to switch to `.getAttribute()`.
* Fixed minor padding issue in titles listing (uneven padding).