### PR TITLE
Testing - Coverage Reports and Additional NPM Scripts 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ webpack.config.js
 webpack.common.config.js
 webpack.dev.config.js
 webpack.prod.config.js
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 yarn.lock
 *.sketch
 dist
+coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ script:
   - npm run lint
   - npm run test
 
+after_script: npx codecov@3
+
 jobs:
   include:
     - stage: prod-build-deploy

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,19 @@ module.exports = {
   displayName: "client",
   moduleFileExtensions: ["js"],
   testEnvironment: "jest-environment-jsdom",
-  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"]
+  setupFilesAfterEnv: ["@testing-library/jest-dom/extend-expect"],
+  coverageThreshold: {
+    global: {
+      statements: 4,
+      branches: 7,
+      functions: 6,
+      lines: 4
+    }
+  },
+  watchPlugins: [
+    "jest-watch-typeahead/filename",
+    "jest-watch-typeahead/testname"
+  ],
+  collectCoverageFrom: ["<rootDir>/assets/scripts/**/*.js"],
+  coveragePathIgnorePatterns: ["__fixtures__"]
 };

--- a/package.json
+++ b/package.json
@@ -20,17 +20,26 @@
     "snyk": "snyk auth && snyk wizard",
     "predeploy": "npm run build:prod",
     "deploy": "gh-pages -d dist",
-    "test": "jest",
-    "test:coverage": "npm run test -- --coverage",
-    "test:watch": "npm run test -- --watch"
+    "test": "is-ci \"test:coverage\" \"test:watch\"",
+    "test:show-config": "jest --showConfig",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch"
   },
   "bugs": {
     "url": "https://github.com/kenchandev/personal-website/issues"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn format:check && yarn lint && yarn test"
+      "pre-commit": "lint-staged && yarn format:check && yarn lint"
     }
+  },
+  "lint-staged": {
+    "**/*.+(js|json|scss|pug|md)": [
+      "prettier",
+      "jest --findRelatedTests",
+      "git add"
+    ]
   },
   "keywords": [
     "website",
@@ -72,7 +81,10 @@
     "html-critical-webpack-plugin": "^2.1.0",
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.1.2",
+    "is-ci-cli": "^2.0.0",
     "jest": "^24.9.0",
+    "jest-watch-typeahead": "^0.4.2",
+    "lint-staged": "^9.5.0",
     "mini-css-extract-plugin": "^0.9.0",
     "ngrok": "^3.1.1",
     "node-sass": "^4.9.3",


### PR DESCRIPTION
* Added coverage report generation and related configurations in `jest.config.js`.
* Added Codecov to `travis.yml` (after all scripts have been executed).
* Added `lint-staged` to perform tests only on recently modified files to be staged for a subsequent commit.
* Added additional test-related NPM scripts.
* Enhanced Jest watch mode with a typeahead plugin for improving the pattern matching (on file / test names) options.