### PR TITLE
IE Patch - Swap Unsupported `.remove()` Method 

### DIFF
--- a/assets/scripts/screenshots.js
+++ b/assets/scripts/screenshots.js
@@ -26,7 +26,7 @@ export const renderScreenshot = (
 
   if (loader.style.display === "none") {
     if (previousScreenshot) {
-      previousScreenshot.remove();
+      previousScreenshot.parentNode.removeChild(previousScreenshot);
     }
 
     loader.style.display = "block";


### PR DESCRIPTION
* `ChildNode.remove()` function is not supported by IE. https://caniuse.com/#search=remove

`.remove()` was swapped for `.parentNode.removeChild(element)`.