### PR TITLE
Travis Configuration - E2E Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ script:
   - npm run format:check
   - npm run lint
   - npm run test
-  - npm run test:e2e
 
 after_script: npx codecov@3
 
@@ -36,7 +35,7 @@ jobs:
       name: "Build Production Site and Deploy to GitHub Pages"
       os: linux
       node_js: "lts/*"
-      script: npm run build:prod && echo "Deploying to GitHub Pages..."
+      script: npm run build:prod && npm run test:e2e && echo "Deploying to GitHub Pages..."
       if: branch = master
       deploy:
         provider: pages

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "jest --watch",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
     "test:e2e": "is-ci \"test:e2e:prod\" \"test:e2e:dev\"",
-    "test:e2e:dev": "start-server-and-test start http://localhost:8889 cy:run",
+    "test:e2e:dev": "start-server-and-test start http://localhost:8889 cy:open",
     "test:e2e:prod": "CYPRESS_baseUrl=http://localhost:5000 start-server-and-test serve http://localhost:5000 cy:run",
     "cy:open": "cypress open",
     "cy:run": "cypress run"
@@ -37,7 +37,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && yarn format:check && yarn lint && yarn test:e2e:dev"
+      "pre-commit": "lint-staged && yarn format:check && yarn lint"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
* Omitted `test:e2e:dev` NPM script from Husky `pre-commit` script. Running E2E tests for every commit became too time consuming.
* Swapped `cy:run` for `cy:open` in `test:e2e:dev` NPM script.
* Moved E2E script to build deploy stage in Travis configuration.