### PR TITLE
`smoothScrollTo` Fail-Safe Check

### DIFF
--- a/assets/scripts/utils.js
+++ b/assets/scripts/utils.js
@@ -77,6 +77,12 @@ export const smoothScrollTo = (scrollTo, scrollDuration) => {
     scrollCount += Math.PI / (scrollDuration / tsDiff);
 
     if (scrollCount >= Math.PI) {
+      //  If the window is already scrolled back to `scrollTo`, then do nothing.
+      //  Otherwise, automatically scroll the window back to `scrollTo`.
+      if (window.pageYOffset !== scrollTo) {
+        window.scrollTo(scrollTo, 0);
+      }
+
       return;
     }
 


### PR DESCRIPTION
Added a fail-safe check to ensure `smoothScrollTo()` scrolls the window back to the specified  `scrollTo` position. There are few occasions for which this method fails to scroll back to the specified `scrollTo` position inconsistent time difference calculations. 