### PR TITLE
Travis CI - Patch Cypress NPM Script

### DIFF
--- a/assets/scripts/form.js
+++ b/assets/scripts/form.js
@@ -22,6 +22,11 @@ class Form {
       this.element.onsubmit = e => {
         e.preventDefault();
 
+        //  Check to prevent Cypress tests from submitting empty form.
+        if (!e.target.checkValidity()) {
+          return;
+        }
+
         // Escape if the honeypot has been filled.
         if (!!this.element.children.namedItem("honeypot").value) {
           return;

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:8889",
   "integrationFolder": "cypress/e2e",
-  "blacklistHosts": ["www.google-analytics.com", "www.googletagmanager.com"]
+  "blacklistHosts": ["www.google-analytics.com", "www.googletagmanager.com"],
+  "chromeWebSecurity": false
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "personal-website",
   "description": "Ken Chan's Personal Website",
   "scripts": {
-    "serve": "serve dist",
+    "serve": "serve -l 3000 dist",
     "start": "webpack-dev-server --host 0.0.0.0 --hot --open --useLocalIp",
     "lint": "esw --color 'assets/scripts/**/*.js'",
     "lint:watch": "npm run lint -- --watch",
@@ -28,7 +28,7 @@
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
     "test:e2e": "is-ci \"test:e2e:prod\" \"test:e2e:dev\"",
     "test:e2e:dev": "start-server-and-test start http://localhost:8889 cy:open",
-    "test:e2e:prod": "CYPRESS_baseUrl=http://localhost:5000 start-server-and-test serve http://localhost:5000 cy:run",
+    "test:e2e:prod": "CYPRESS_baseUrl=http://localhost:3000 start-server-and-test serve http://localhost:3000 cy:run",
     "cy:open": "cypress open",
     "cy:run": "cypress run"
   },


### PR DESCRIPTION
* Prevent Cypress `submit()` method from submitting empty form (bypasses HTML5 validation).
* Changed localhost port for `serve` NPM script from 5000 to 3000 due to CORS error for SES endpoint.
* Disabled Cypress Chrome security setting to prevent frame from being blocked during testing for `http://localhost:3000`.

  ```
  SecurityError: Blocked a frame with origin "http://localhost:3000" from accessing a cross-origin frame.
  ```

