### PR TITLE
Dev. Build Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         local-dir: dist/
         github-token: $GITHUB_API_KEY
         keep-history: true
-        repo: kenchandev/dev.kenchandev.github.io
+        repo: kenchandev/dev
         target-branch: master
         on:
           branch: dev


### PR DESCRIPTION
Changed deployment repository to `dev` from `dev.kenchandev.github.io`.